### PR TITLE
Add KubeStellar Console to Others section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ application for the Graphite Real-time graphing engine.
 * [Hawtio](http://hawt.io) - A  modular web console for managing your Java stuff.
 * [Hystrix Dashboard](https://github.com/Netflix-Skunkworks/hystrix-dashboard) - The [Hystrix](https://github.com/Netflix/Hystrix) Dashboard enables realtime monitoring of Hystrix metrics.
 * [ng2 Admin](https://github.com/akveo/ng2-admin) - Solid Angular2 admin dashboard, based on [Angular2 Webpack Starter](https://github.com/AngularClass/angular2-webpack-starter)
+* [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with 150+ real-time monitoring cards and CNCF integrations.
 
 # Contribution Guidelines
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://console.kubestellar.io) to the **Others** section.

KubeStellar Console is an open-source, AI-powered multi-cluster Kubernetes dashboard with 150+ real-time monitoring cards, 15 themes, and integrations with 30+ CNCF projects (Prometheus, Grafana, Jaeger, etc.).

- � Live: https://console.kubestellar.io
- 📦 Source: https://github.com/kubestellar/console
- 📜 License: Apache-2.0
- 🏛️ CNCF Sandbox project (under KubeStellar)