### PR TITLE
Add OpenChainBench to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ application for the Graphite Real-time graphing engine.
 * [Hystrix Dashboard](https://github.com/Netflix-Skunkworks/hystrix-dashboard) - The [Hystrix](https://github.com/Netflix/Hystrix) Dashboard enables realtime monitoring of Hystrix metrics.
 * [ng2 Admin](https://github.com/akveo/ng2-admin) - Solid Angular2 admin dashboard, based on [Angular2 Webpack Starter](https://github.com/AngularClass/angular2-webpack-starter)
 * [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with 150+ real-time monitoring cards and CNCF integrations.
+* [OpenChainBench](https://openchainbench.com) - Public dashboards for blockchain RPC provider benchmarks. Multi-region Prometheus scraping with a Next.js front-end, all data and methodology exposed.
 
 # Contribution Guidelines
 


### PR DESCRIPTION
Adds OpenChainBench under Others. It is a public dashboard for blockchain RPC provider benchmarks with multi-region Prometheus scraping and a Next.js front-end. All data and methodology are exposed.

Thanks for maintaining the list.