### PR TITLE
Add Xenon dashboard to General

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [Contribution Guidelines](#contribution-guidelines)
 * [StyleBI](https://github.com/inetsoft-technology/stylebi) - App for dashboards and analytics with data pipeline for transformation and mashup.
 * [Shaper](https://taleshape.com/shaper/docs/) - Open-Source SQL-First, Data Dashboards and Embedded Analytics. Powered By DuckDB.
 * [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit that generates a single-page DNA Terminal dashboard with green-on-black terminal aesthetic.
+* [Xenon](https://github.com/marcimastro98/Xenon) - Local all-in-one PC dashboard that runs in any browser or on the CORSAIR Xeneon Edge touchscreen: system monitor, media, mic, voice AI, a Stream-Deck grid, and RGB lighting. 100% local, no account.
 
 ## Graphite
 


### PR DESCRIPTION
Adds **Xenon** to the General section.

[Xenon](https://github.com/marcimastro98/Xenon) is a 100% local, all-in-one PC dashboard that runs in any Chromium browser or on the CORSAIR Xeneon Edge touchscreen. It provides a system monitor (CPU/GPU/RAM/network/disk), media & mic control, a voice AI that can build dashboard pages, a Stream-Deck-style key grid, and RGB lighting. Free, open source, no account, no cloud, no telemetry.

- Source code: https://github.com/marcimastro98/Xenon
- Documentation is in English
- Actively maintained