### PR TITLE
docs: add AppRankly to General section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See [Contribution Guidelines](#contribution-guidelines)
 * [Apache Superset](https://github.com/apache/incubator-superset) - a modern, enterprise-ready business intelligence web application (previously named Caravel and Panoramix).
 * [awe](https://github.com/dankilman/awe) - A framework for creating dynamic web based reports and dashboards.
 * [frolic](https://github.com/FrolicOrg/Frolic) - Backend service to build customer facing dashboards 10x faster. Written in Rust.
+* [AppRankly](https://github.com/zmsp/AppRankly) - Self-hosted mobile app store analytics dashboard for iOS App Store Connect and Google Play Console.
 * [AppSmith](https://github.com/appsmithorg/appsmith)) - Platform to build admin panels, internal tools, and dashboards. Integrates with 25+ databases and any API.
 * [StyleBI](https://github.com/inetsoft-technology/stylebi) - App for dashboards and analytics with data pipeline for transformation and mashup.
 * [Shaper](https://taleshape.com/shaper/docs/) - Open-Source SQL-First, Data Dashboards and Embedded Analytics. Powered By DuckDB.


### PR DESCRIPTION
## Description

Adds AppRankly to the **General** section.

AppRankly is a self-hosted mobile app store analytics dashboard for iOS App Store Connect and Google Play Console.

## Checklist
- [x] Meets awesome-dashboard submission standards
- [x] Placed alphabetically in General section