### PR TITLE
Add DAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See [Contribution Guidelines](#contribution-guidelines)
 * [Shaper](https://taleshape.com/shaper/docs/) - Open-Source SQL-First, Data Dashboards and Embedded Analytics. Powered By DuckDB.
 * [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - A personal genome analysis toolkit that generates a single-page DNA Terminal dashboard with green-on-black terminal aesthetic.
 * [Xenon](https://github.com/marcimastro98/Xenon) - Local all-in-one PC dashboard that runs in any browser or on the CORSAIR Xeneon Edge touchscreen: system monitor, media, mic, voice AI, a Stream-Deck grid, and RGB lighting. 100% local, no account.
+* [DAC](https://github.com/bruin-data/dac) - Dashboard-as-code tool that defines dashboards in YAML and TSX, with a built-in semantic layer.
 
 ## Graphite
 


### PR DESCRIPTION
Adds [DAC](https://github.com/bruin-data/dac) to the **General** section.

DAC is an open-source (AGPL-3.0) dashboard-as-code tool. Dashboards are defined in YAML or TSX files, version-controlled and reviewable like any other code, and served from a single Go binary. It has a built-in semantic layer for defining metrics and dimensions once, and connects to Postgres, MySQL, Snowflake, BigQuery, Redshift, Databricks and others. ~700 stars, actively developed.

Guidelines checklist:
- Searched the list and prior PRs first; not a duplicate.
- Individual pull request for this one suggestion.
- Format `* [RESOURCE](LINK) - DESCRIPTION.`, short, ending with a period.
- Added to the existing General category; no new category needed.

Disclosure: I work on the team that builds DAC.